### PR TITLE
ci: remove elixir 1.18

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -16,8 +16,8 @@ jobs:
 
     strategy:
       matrix:
-        otp: ['24', '25', '26', '27']
-        elixir: ['1.15', '1.16', '1.17', '1.18']
+        otp: ['25', '26', '27']
+        elixir: ['1.17']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/elixir_unlocked.yml
+++ b/.github/workflows/elixir_unlocked.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         otp: ['24', '25', '26', '27']
-        elixir: ['1.15', '1.16', '1.17', '1.18']
+        elixir: ['1.15', '1.16', '1.17']
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Remove elixir 1.18 from the build matrix because it's not supported by setup-beam.